### PR TITLE
AB#34086 Multiple egress sonar ips

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ We also need to configure the MySQL server to allow remote access from Sonar, so
 
 This makes the MySQL server listen for connections on all interfaces on the server, rather than just to localhost (127.0.0.1). Now we need to setup a remote user account, so that your Sonar instance can access the database. To do this, select **Add a remote access user** in the same menu.
 
-Genie will ask you for the IP address of the remote server. If you don't know the IP of your Sonar instance, you can ping it to get the IP:
+Genie will ask you to use the defaults or the IP address of the remote server. It is recommended to use the Sonar defaults for Sonar V2 instances. If using Sonar V1 and you don't know the IP of your Sonar instance, you can ping it to get the IP:
 
 ![Ping](https://github.com/SonarSoftware/freeradius_genie/blob/master/images/ping.png)
 

--- a/src/DatabaseSetup.php
+++ b/src/DatabaseSetup.php
@@ -156,16 +156,14 @@ class DatabaseSetup
         $stc = $this->dbh->prepare("CREATE USER ?@? IDENTIFIED BY ?");
         $sth = $this->dbh->prepare("GRANT ALL ON radius.* TO ?@?");
         for ($i=0; $i < count($ipAddresses); $i++) {
-            if ($stc->execute([$username, $ipAddresses[$i], $password]) && $sth->execute([$username, $ipAddresses[$i]]))
-            {
-                $this->dbh->prepare("FLUSH PRIVILEGES")->execute();
-                $this->climate->lightMagenta("Added a user with the username $username and the password $password. Copy this username and password, you'll need it!");
-            }
-            else
+            if (!$stc->execute([$username, $ipAddresses[$i], $password]) || !$sth->execute([$username, $ipAddresses[$i]]))
             {
                 $this->climate->shout("Failed to create the user!");
+                break;
             }
         }
+        $this->dbh->prepare("FLUSH PRIVILEGES")->execute();
+        $this->climate->lightMagenta("Added a user with the username $username and the password $password. Copy this username and password, you'll need it!");
     }
 
     /**

--- a/src/DatabaseSetup.php
+++ b/src/DatabaseSetup.php
@@ -155,15 +155,19 @@ class DatabaseSetup
 
         $stc = $this->dbh->prepare("CREATE USER ?@? IDENTIFIED BY ?");
         $sth = $this->dbh->prepare("GRANT ALL ON radius.* TO ?@?");
+        $success = true;
         for ($i=0; $i < count($ipAddresses); $i++) {
             if (!$stc->execute([$username, $ipAddresses[$i], $password]) || !$sth->execute([$username, $ipAddresses[$i]]))
             {
                 $this->climate->shout("Failed to create the user!");
+                $success = false;
                 break;
             }
         }
-        $this->dbh->prepare("FLUSH PRIVILEGES")->execute();
-        $this->climate->lightMagenta("Added a user with the username $username and the password $password. Copy this username and password, you'll need it!");
+        if ($success) {
+            $this->dbh->prepare("FLUSH PRIVILEGES")->execute();
+            $this->climate->lightMagenta("Added a user with the username $username and the password $password. Copy this username and password, you'll need it!");
+        }
     }
 
     /**

--- a/src/DatabaseSetup.php
+++ b/src/DatabaseSetup.php
@@ -115,20 +115,31 @@ class DatabaseSetup
      */
     public function addRemoteAccessUser()
     {
-        $input = $this->climate->lightBlue()->input("What is the IP address of the remote server that will be accessing the database?");
+        $input = $this->climate->lightBlue()->input("Enter 'd' for Sonar defaults or IP address of the remote server that will be accessing the database.");
+        $ipAddresses = [];
         $ipAddress = null;
         while ($ipAddress == null || filter_var($ipAddress, FILTER_VALIDATE_IP) === false)
         {
             $ipAddress = $input->prompt();
             if ($ipAddress == null)
             {
-                $this->climate->shout("You must input an IP address.");
+                $this->climate->shout("You must input an IP address or 'd' for Sonar defaults.");
+            }
+            elseif ($ipAddress === 'd')
+            {
+                $this->climate->lightMagenta("Using egress IPs of Sonar..");
+                $ipAddresses = ['20.221.112.37', '20.221.114.13', '52.158.209.86'];
             }
             elseif (filter_var($ipAddress, FILTER_VALIDATE_IP) === false)
             {
                 $this->climate->shout("That IP address is not valid.");
             }
+            else
+            {
+                $ipAddresses[] = $ipAddress;
+            }
         }
+        
 
         $characters = 'abcdefghijklmnopqrstuvwxyz0123456789';
         $username = '';
@@ -142,15 +153,17 @@ class DatabaseSetup
         }
 
         $sth = $this->dbh->prepare("GRANT ALL ON radius.* TO ?@? IDENTIFIED BY ?");
-        if ($sth->execute([$username, $ipAddress, $password]))
-        {
-            $sth = $this->dbh->prepare("FLUSH PRIVILEGES");
-            $sth->execute();
-            $this->climate->lightMagenta("Added a user with the username $username and the password $password. Copy this username and password, you'll need it!");
-        }
-        else
-        {
-            $this->climate->shout("Failed to create the user!");
+        for ($i=0; $i < count($ipAddresses); i++) {
+            if ($sth->execute([$username, $ipAddresses[$i], $password]))
+            {
+                $sth = $this->dbh->prepare("FLUSH PRIVILEGES");
+                $sth->execute();
+                $this->climate->lightMagenta("Added a user with the username $username and the password $password. Copy this username and password, you'll need it!");
+            }
+            else
+            {
+                $this->climate->shout("Failed to create the user!");
+            }
         }
     }
 

--- a/src/DatabaseSetup.php
+++ b/src/DatabaseSetup.php
@@ -129,6 +129,7 @@ class DatabaseSetup
             {
                 $this->climate->lightMagenta("Using egress IPs of Sonar..");
                 $ipAddresses = ['20.221.112.37', '20.221.114.13', '52.158.209.86'];
+                break;
             }
             elseif (filter_var($ipAddress, FILTER_VALIDATE_IP) === false)
             {
@@ -152,12 +153,12 @@ class DatabaseSetup
             $password .= $characters[rand(0, strlen($characters) - 1)];
         }
 
-        $sth = $this->dbh->prepare("GRANT ALL ON radius.* TO ?@? IDENTIFIED BY ?");
-        for ($i=0; $i < count($ipAddresses); i++) {
-            if ($sth->execute([$username, $ipAddresses[$i], $password]))
+        $stc = $this->dbh->prepare("CREATE USER ?@? IDENTIFIED BY ?");
+        $sth = $this->dbh->prepare("GRANT ALL ON radius.* TO ?@?");
+        for ($i=0; $i < count($ipAddresses); $i++) {
+            if ($stc->execute([$username, $ipAddresses[$i], $password]) && $sth->execute([$username, $ipAddresses[$i]]))
             {
-                $sth = $this->dbh->prepare("FLUSH PRIVILEGES");
-                $sth->execute();
+                $this->dbh->prepare("FLUSH PRIVILEGES")->execute();
                 $this->climate->lightMagenta("Added a user with the username $username and the password $password. Copy this username and password, you'll need it!");
             }
             else


### PR DESCRIPTION
This adds support for creating the remote access user entries necessary for Sonar to connect from 3 different egress IP addresses.  I tested the new workflow on Ubuntu server running freeradius.  Adds a new option "Press d to use defaults" so the user doesn't need to think about anything, just press d.